### PR TITLE
Calculate age of post at client

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -37,6 +37,9 @@
     <link rel="micropub" href="{{ . }}">{{ end }} {{ with .Site.Params.microsubUrl }}
     <link rel="microsub" href="{{ . }}">{{ end }}
 
+    <!-- Neofeed utils -->
+    <script src="/js/neofeed-utils.js"></script>
+
     <!-- Silos -->
     <meta property="og:url" content="{{ .Site.BaseURL }}" />
     <meta property="og:title" content="{{ .Site.Title }}" />

--- a/layouts/partials/properties.html
+++ b/layouts/partials/properties.html
@@ -4,17 +4,26 @@
             {{ if .Date }}
             <span class="dt-published hidden">{{ .Date }}</span>
             <a class="icon u-url" href="{{.Permalink}}">
-                {{ $diff := div (sub now.Unix .Date.Unix) 86400 }}
-                {{ if eq $diff 0 }}earlier today
-                {{ else }}
-                {{ if eq $diff -1 }}a day from now
-                {{ else }}
-                {{ if lt $diff 0 }}{{ mul -1 $diff }} days in the future
-                {{ else }}
-                {{ if eq $diff 1 }}a day ago
-                {{ else }}
-                {{ $diff }} days ago
-                {{ end }}{{ end }}{{ end }}{{ end }}
+                <noscript>
+                    {{ $diff := div (sub now.Unix .Date.Unix) 86400 }}
+                    {{ if eq $diff 0 }}earlier today
+                    {{ else }}
+                    {{ if eq $diff -1 }}a day from now
+                    {{ else }}
+                    {{ if lt $diff 0 }}{{ mul -1 $diff }} days in the future
+                    {{ else }}
+                    {{ if eq $diff 1 }}a day ago
+                    {{ else }}
+                    {{ $diff }} days ago
+                    {{ end }}{{ end }}{{ end }}{{ end }}
+                </noscript>
+                <script>
+                    // The last script element is the current one at the time of execution.
+                    var scriptNodes = document.getElementsByTagName('script');
+                    var scriptNode = scriptNodes[scriptNodes.length - 1];
+                    var parentNode = scriptNode.parentNode;
+                    parentNode.innerText = calcDateDiff({{ .Date.Unix }});
+                </script>
             </a>
             {{ end }}
         </span>

--- a/static/js/neofeed-utils.js
+++ b/static/js/neofeed-utils.js
@@ -1,0 +1,14 @@
+function calcDateDiff(unixTimestamp) {
+    const diff = Math.floor((Date.now() / 1000 - unixTimestamp) / 86400);
+    if (diff == 0) {
+        return "earlier today";
+    } else if (diff == -1) {
+        return "a day from now";
+    } else if (diff < 0) {
+        return `${diff * -1} days in the future`;
+    } else if (diff == 1) {
+        return "a day ago";
+    } else {
+        return `${diff} days ago`;
+    }
+}


### PR DESCRIPTION
Currently, the age of a post is calculated when the site is deployed. If the site is not updated or redeployed daily, the age of a post becomes outdated quickly.

With this fix, the age gets calculated at the client using JavaScript. If JavaScript isn't available, the old method is still available as a fallback.