### PR TITLE
Fix 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# template from https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+# non-template additions
+.hugo_build.lock
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,4 @@ dev: ## Run the local development server
 	hugo serve --enableGitInfo --disableFastRender --environment development
 
 demo: ## Serve this site locally using the exampleSite
-	cd exampleSite/ && hugo server --themesDir ../.. -v -t neofeed
+	cd exampleSite/ && hugo server -v

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -48,3 +48,8 @@ feed = "/:title/"
 [outputs]
 # Output formats for your feed. You probably don't need to change this.
   home = ["HTML", "JSON", "RSS"]
+
+# use published module to include theme
+[module]
+[[module.imports]]
+  path = 'github.com/victoriadrake/neofeed-theme/v2'

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -1,0 +1,7 @@
+module github.com/victoriadrake/neofeed-theme/exampleSite
+
+go 1.16
+
+require github.com/victoriadrake/neofeed-theme/v2 v2.0.6
+
+replace github.com/victoriadrake/neofeed-theme/v2 => ../


### PR DESCRIPTION
Change the theme loading approach of the exampleSite to fix "make demo"

this PR establishes the exampleSite as it's own go.mod to explicitly track the theme itself as a dependency. It also edits the config.toml of the exampleSite to load the theme module independently of the hugo CLI command in the makefile

I'm pretty new to hugo and as such not confident that this is the cleanest solution. I thus followed [this theme](https://github.com/bep/docuapi) from [this issue](https://discourse.gohugo.io/t/how-do-i-do-theme-development-with-an-example-site-in-the-repo/2136/12) as an example of the pattern

Let me know if there's another approach you see to solving this issue with your additional context :) 